### PR TITLE
ci: harden workflows with least-privilege permissions, timeouts, and fixes

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - 'foundation-**'
       - 'release-**'
+permissions:
+  pull-requests: write
+
 jobs:
   assign_reviewer:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,15 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build:
     if: "!contains(github.event.head_commit.message || '', '[skip build]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,18 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+# Workflow-level permissions define the ceiling for all calling jobs.
+# For reusable workflow calls, job-level permissions cannot exceed these.
+# Individual jobs below further restrict their own scope as needed.
+# contents: write  - package-publish needs this to create GitHub releases
+# packages: write  - package-publish needs this to push OCI images to GHCR
+# checks: write    - test jobs need this to publish JUnit check reports
+# actions: write   - all jobs need this for artifact upload/download
 permissions:
-  contents: read
+  contents: write
+  packages: write
+  checks: write
+  actions: write
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -24,25 +25,39 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      actions: write
 
   unit-tests:
     needs: build
     uses: ./.github/workflows/test-unit.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      checks: write
+      actions: write
 
   integration-tests:
     needs: unit-tests
     uses: ./.github/workflows/test-integration.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      checks: write
+      actions: write
 
   e2e-tests:
     needs: unit-tests
     uses: ./.github/workflows/test-e2e.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      checks: write
+      actions: write
 
   package-publish:
     needs: [integration-tests, e2e-tests]
     uses: ./.github/workflows/package-publish.yml
-    permissions: write-all
+    permissions:
+      contents: write
+      packages: write
+      actions: write
     secrets: inherit

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -5,12 +5,16 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: write
+  packages: write
+  actions: write
 
 jobs:
   core-packages:
     if: "!contains(github.event.head_commit.message || '', '[skip core-packages]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -35,6 +39,7 @@ jobs:
   minion-packages:
     if: "!contains(github.event.head_commit.message || '', '[skip minion-packages]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -59,6 +64,7 @@ jobs:
   sentinel-packages:
     if: "!contains(github.event.head_commit.message || '', '[skip sentinel-packages]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -83,6 +89,7 @@ jobs:
   core-oci:
     if: "!contains(github.event.head_commit.message || '', '[skip core-oci]') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -121,6 +128,14 @@ jobs:
           echo "GIT_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
           echo "TAG=${VERSION:-$(git rev-parse --short HEAD)}" >> ${GITHUB_ENV}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            TAGS="${TAGS},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Build and push Core container image
         uses: docker/build-push-action@v6
         with:
@@ -135,11 +150,12 @@ jobs:
             SOURCE=${{ github.server_url }}/${{ github.repository }}/tree/${{ env.GIT_SHA }}/opennms-container/core
             BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             BUILD_JOB_ID=${{ github.run_id }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   minion-oci:
     if: "!contains(github.event.head_commit.message || '', '[skip minion-oci]') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -184,6 +200,14 @@ jobs:
           echo "GIT_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
           echo "TAG=${VERSION:-$(git rev-parse --short HEAD)}" >> ${GITHUB_ENV}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            TAGS="${TAGS},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Build and push Minion container image
         uses: docker/build-push-action@v6
         with:
@@ -198,11 +222,12 @@ jobs:
             SOURCE=${{ github.server_url }}/${{ github.repository }}/tree/${{ env.GIT_SHA }}/opennms-container/minion
             BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             BUILD_JOB_ID=${{ github.run_id }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   sentinel-oci:
     if: "!contains(github.event.head_commit.message || '', '[skip sentinel-oci]') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -240,6 +265,14 @@ jobs:
           echo "GIT_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
           echo "TAG=${VERSION:-$(git rev-parse --short HEAD)}" >> ${GITHUB_ENV}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            TAGS="${TAGS},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Build and push Sentinel container image
         uses: docker/build-push-action@v6
         with:
@@ -254,11 +287,12 @@ jobs:
             SOURCE=${{ github.server_url }}/${{ github.repository }}/tree/${{ env.GIT_SHA }}/opennms-container/sentinel
             BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             BUILD_JOB_ID=${{ github.run_id }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   daemon-oci:
     if: "!contains(github.event.head_commit.message || '', '[skip daemon-oci]') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -296,6 +330,14 @@ jobs:
           echo "GIT_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
           echo "TAG=${VERSION:-$(git rev-parse --short HEAD)}" >> ${GITHUB_ENV}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            TAGS="${TAGS},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Build and push Daemon container image
         uses: docker/build-push-action@v6
         with:
@@ -310,11 +352,12 @@ jobs:
             SOURCE=${{ github.server_url }}/${{ github.repository }}/tree/${{ env.GIT_SHA }}/opennms-container/daemon
             BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             BUILD_JOB_ID=${{ github.run_id }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   alarmd-oci:
     if: "!contains(github.event.head_commit.message || '', '[skip alarmd-oci]') || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -352,6 +395,14 @@ jobs:
           echo "GIT_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> ${GITHUB_ENV}
           echo "TAG=${VERSION:-$(git rev-parse --short HEAD)}" >> ${GITHUB_ENV}
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            TAGS="${TAGS},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Build and push Alarmd container image
         uses: docker/build-push-action@v6
         with:
@@ -366,16 +417,20 @@ jobs:
             SOURCE=${{ github.server_url }}/${{ github.repository }}/tree/${{ env.GIT_SHA }}/opennms-container/alarmd
             BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             BUILD_JOB_ID=${{ github.run_id }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:${{ env.TAG }},ghcr.io/${{ github.repository_owner }}/${{ env.OCI_REPOSITORY }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   create-github-release:
     needs:
       - core-packages
       - minion-packages
       - sentinel-packages
+      - core-oci
+      - minion-oci
+      - sentinel-oci
       - daemon-oci
       - alarmd-oci
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,7 +6,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
+  actions: write
 
 jobs:
   e2e-core:
@@ -17,6 +20,7 @@ jobs:
         shard_idx: [0, 1, 2, 3, 4, 5, 6, 7]
         shards: [8]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -42,9 +46,10 @@ jobs:
           make core-e2e MAVEN_SHARD_IDX=${{ matrix.shard_idx }} MAVEN_SHARDS=${{ matrix.shards }}
       - name: Publish Core E2E Test Report (shard ${{ matrix.shard_idx }})
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: "Core E2E Test Report (shard ${{ matrix.shard_idx }})"
+          report_paths: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
       - name: Collect test results and logs
         if: always()
         run: |
@@ -69,6 +74,7 @@ jobs:
         shard_idx: [0]
         shards: [1]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -94,9 +100,10 @@ jobs:
           make minion-e2e MAVEN_SHARD_IDX=${{ matrix.shard_idx }} MAVEN_SHARDS=${{ matrix.shards }}
       - name: Publish Minion E2E Test Report (shard ${{ matrix.shard_idx }})
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: "Minion E2E Test Report (shard ${{ matrix.shard_idx }})"
+          report_paths: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
       - name: Collect test results and logs
         if: always()
         run: |
@@ -121,6 +128,7 @@ jobs:
         shard_idx: [0]
         shards: [1]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -146,9 +154,10 @@ jobs:
           make sentinel-e2e MAVEN_SHARD_IDX=${{ matrix.shard_idx }} MAVEN_SHARDS=${{ matrix.shards }}
       - name: Publish Sentinel E2E Test Report (shard ${{ matrix.shard_idx }})
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: "Sentinel E2E Test Report (shard ${{ matrix.shard_idx }})"
+          report_paths: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
       - name: Collect test results and logs
         if: always()
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,12 +6,16 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
+  actions: write
 
 jobs:
   integration-tests:
     if: "!contains(github.event.head_commit.message || '', '[skip integration-tests]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -55,9 +59,10 @@ jobs:
 
       - name: Publish Integration Test Report (shard ${{ matrix.shard_idx }})
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: Integration Test Report (shard ${{ matrix.shard_idx }})
+          report_paths: '**/target/failsafe-reports/TEST-*.xml,**/target/surefire-reports/TEST-*.xml'
 
       - name: Collect test results and logs (shard ${{ matrix.shard_idx }})
         if: always()

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -6,12 +6,16 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
+  actions: write
 
 jobs:
   unit-tests:
     if: "!contains(github.event.head_commit.message || '', '[skip unit-tests]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -45,9 +49,10 @@ jobs:
 
       - name: Publish Unit Test Report (shard ${{ matrix.shard_idx }})
         if: success() || failure()
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v4
         with:
           check_name: Unit Test Report (shard ${{ matrix.shard_idx }})
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
 
       - name: Collect test results and logs (shard ${{ matrix.shard_idx }})
         if: always()


### PR DESCRIPTION
- Scope down permissions from write-all to minimum required per workflow
- Add timeout-minutes to all jobs to prevent runaway builds
- Guard :latest OCI tag to only push on tags and develop branch
- Add core-oci, minion-oci, sentinel-oci to create-github-release needs
- Replace deprecated scacap/action-surefire-report@v1 with mikepenz/action-junit-report@v4
- Add explicit permissions to auto-assign workflow

https://claude.ai/code/session_01ASb88GsLRKPZjF48hHSAh1